### PR TITLE
Fixed test name

### DIFF
--- a/test.js
+++ b/test.js
@@ -112,7 +112,7 @@ test('it concats 2 async finite listenable sources', t => {
   }, 1200);
 });
 
-test('it concats 2 async finite pullable sources', t => {
+test('it concats 2 sync finite pullable sources', t => {
   t.plan(30);
 
   const upwardsExpectedA = [1, 1,1,1];


### PR DESCRIPTION
Because you have issues disabled on this repository, I'd like to ask smth/discuss.

It seems to me that [this](https://github.com/staltz/callbag-concat/blob/b402eab313264e13080d08efad61b3741fa9f870/readme.js#L49) breaks somewhat `concat`'s transparency, because:
- upwards 1 can be sent with data
- upwards 1s dont have to be synchronous, they can be backpressured etc but now `concat` assumes it has to pull when subscribing to new source

This means that `concat`enated pullable sources might behave differently than a single source combining (I dont mean combining in stream semantics) those 2 sources.

Problem is that `concat` doesnt know if the emitted value is the last one (because 2 is separate message), I've tried to "fix" this with keeping `requesting` & `sending` flags and postponing 2nd action till 1st one finishes to detect sync `1`+`2` emits (happening between `requesting = true` & `requesting = false`) etc, but this seriously hurts my brain 😉 and I cannot achieve my expected results.

To sum it up - do you think it's a problem? I might be overthinking this 😄.

I know that callbags is just a protocol for communication and it doesnt assume much about those things, but still would be great to cover such cases in operators/sources if possible.