### PR TITLE
New subscribed source being pulled only if needed

### DIFF
--- a/readme.js
+++ b/readme.js
@@ -24,6 +24,8 @@
  *                                           // b
  */
 
+const UNIQUE = {};
+
 const concat = (...sources) => (start, sink) => {
   if (start !== 0) return;
   const n = sources.length;
@@ -34,7 +36,7 @@ const concat = (...sources) => (start, sink) => {
   }
   let i = 0;
   let sourceTalkback;
-  let lastPull;
+  let lastPull = UNIQUE;
   const talkback = (t, d) => {
     if (t === 1) lastPull = d;
     sourceTalkback(t, d);
@@ -48,7 +50,7 @@ const concat = (...sources) => (start, sink) => {
       if (t === 0) {
         sourceTalkback = d;
         if (i === 0) sink(0, talkback);
-        else sourceTalkback(1, lastPull);
+        else if (lastPull !== UNIQUE) sourceTalkback(1, lastPull);
       } else if (t === 2 && d) {
         sink(2, d);
       } else if (t === 2) {


### PR DESCRIPTION
**Why?**

`startWith` can be expressed as:
```js
const startWith = (...xs) => source => concat(of(...xs), source);
```

and it seems to me that in such a scenario

```js
pipe(
  fromIter([3,4,5]),
  startWith(1, 2),
  pullWhen(interval(1000)),
  forEach(x => {
    console.log(x)
  })
)
```

1, 2 should be delivered asap, but 3, 4, 5 should be delivered within 1s intervals after that. Having unconditional pull in `concat` makes 3 to being delivered asap too.

EDIT: // when I think about it now, we should probably do smth like
```js
else if (lastPull !== UNIQUE) {
  const last = lastPull
  lastPull = UNIQUE
  sourceTalkback(1, last);
}
```
to account for changing pulling behaviour over time. WDYT?